### PR TITLE
made the failing tests (user_edit_spec and sign_up_spec) green

### DIFF
--- a/lib/generators/testing/configure/templates/spec/devise/features/users/user_edit_spec.rb
+++ b/lib/generators/testing/configure/templates/spec/devise/features/users/user_edit_spec.rb
@@ -22,7 +22,8 @@ feature 'User edit', :devise do
     fill_in 'Email', :with => 'newemail@example.com'
     fill_in 'Current password', :with => user.password
     click_button 'Update'
-    expect(page).to have_content I18n.t 'devise.registrations.updated'
+    txts = [I18n.t( 'devise.registrations.updated'), I18n.t( 'devise.registrations.update_needs_confirmation')]
+    expect(page).to have_content(/.*#{txts[0]}.*|.*#{txts[1]}.*/)
   end
 
   # Scenario: User cannot edit another user's profile

--- a/lib/generators/testing/configure/templates/spec/devise/features/visitors/sign_up_spec.rb
+++ b/lib/generators/testing/configure/templates/spec/devise/features/visitors/sign_up_spec.rb
@@ -10,7 +10,8 @@ feature 'Sign Up', :devise do
   #   Then I see a successful sign up message
   scenario 'visitor can sign up with valid email address and password' do
     sign_up_with('test@example.com', 'please123', 'please123')
-    expect(page).to have_content I18n.t 'devise.registrations.signed_up'
+    txts = [I18n.t( 'devise.registrations.signed_up'), I18n.t( 'devise.registrations.signed_up_but_unconfirmed')]
+    expect(page).to have_content(/.*#{txts[0]}.*|.*#{txts[1]}.*/)
   end
 
   # Scenario: Visitor cannot sign up with invalid email address


### PR DESCRIPTION
reason for changing the tests is that once a user selects to add the :confirmable into the Devise features, these tests will fail due to the I18n translations
